### PR TITLE
feat: 게시글 삭제, 게시글 키워드 태그 추가, 피드 조회 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+**/src/main/generated
+
 ### STS ###
 .apt_generated
 .classpath

--- a/api/src/main/java/com/team/App.java
+++ b/api/src/main/java/com/team/App.java
@@ -1,7 +1,9 @@
 package com.team;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class App {
     public static void main(String[] args) {

--- a/api/src/main/java/com/team/post/PostController.java
+++ b/api/src/main/java/com/team/post/PostController.java
@@ -5,11 +5,9 @@ import com.team.post.dto.request.SavePostRequest;
 import com.team.post.dto.response.SavePostResponse;
 import com.team.post.util.ImageUploader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
 
@@ -38,6 +36,13 @@ public class PostController {
         return ResponseEntity
                 .created(uriComponents.toUri())
                 .body(new SavePostResponse(output));
+    }
+
+    @DeleteMapping("/{post-id}")
+    public ResponseEntity<Void> deletePost(@PathVariable("post-id") Long postId) {
+        postService.delete(postId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
     }
 
     private List<Long> saveImages(SavePostRequest request) {

--- a/api/src/main/java/com/team/post/dto/request/SavePostRequest.java
+++ b/api/src/main/java/com/team/post/dto/request/SavePostRequest.java
@@ -22,12 +22,15 @@ public class SavePostRequest {
 
     private List<Long> taggedUserIds;
 
+    private List<String> taggedKeywords;
+
     @Builder
-    public SavePostRequest(Long userId, String content, List<MultipartFile> postImages, List<Long> taggedUserIds) {
+    public SavePostRequest(Long userId, String content, List<MultipartFile> postImages, List<Long> taggedUserIds, List<String> taggedKeywords) {
         this.userId = userId;
         this.content = content;
         this.postImages = postImages;
         this.taggedUserIds = taggedUserIds;
+        this.taggedKeywords = taggedKeywords;
     }
 
     public SavePostInput toInput(List<Long> postImageIds) {
@@ -36,6 +39,7 @@ public class SavePostRequest {
                 .content(content)
                 .postImageIds(postImageIds)
                 .taggedUserIds(taggedUserIds)
+                .taggedKeywords(taggedKeywords)
                 .build();
     }
 }

--- a/api/src/main/java/com/team/post/dto/response/FeedResponse.java
+++ b/api/src/main/java/com/team/post/dto/response/FeedResponse.java
@@ -1,0 +1,49 @@
+package com.team.post.dto.response;
+
+import com.team.post.dto.output.FeedOutput;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access =  AccessLevel.PROTECTED)
+public class FeedResponse {
+    private List<FeedResponse.FeedInfo> feedInfos;
+
+    public FeedResponse(FeedOutput feed) {
+        this.feedInfos = feed.getFeedInfos().stream()
+                .map(FeedResponse.FeedInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FeedInfo {
+        private Long userId;
+        private Long postId;
+        private String nickname;
+        private String profileImage;
+        private String content;
+        private String createdAt;
+        private List<String> imagePaths;
+        private List<String> uploadImageNames;
+        private int likeCount;
+        private int commentCount;
+
+        public FeedInfo(FeedOutput.FeedInfo output) {
+            this.userId = output.getUserId();
+            this.postId = output.getPostId();
+            this.nickname = output.getNickname();
+            this.profileImage = output.getProfileImage();
+            this.content = output.getContent();
+            this.createdAt = output.getCreatedAt();
+            this.imagePaths = output.getImagePaths();
+            this.uploadImageNames = output.getUploadImageNames();
+            this.likeCount = output.getLikeCount();
+            this.commentCount = output.getCommentCount();
+        }
+    }
+}

--- a/api/src/main/java/com/team/post/dto/response/SavePostResponse.java
+++ b/api/src/main/java/com/team/post/dto/response/SavePostResponse.java
@@ -16,8 +16,8 @@ public class SavePostResponse {
     private String content;
     private List<String> postImages;
     private List<Long> taggedUserIds;
+    private List<String> taggedKeywords;
     private LocalDateTime createdAt;
-    private LocalDateTime lastModified;
 
     public SavePostResponse(SavePostOutput output) {
         this.userId = output.getUserId();
@@ -25,7 +25,7 @@ public class SavePostResponse {
         this.content = output.getContent();
         this.postImages = output.getPostImages();
         this.taggedUserIds = output.getTaggedUserIds();
+        this.taggedKeywords = output.getTaggedKeywords();
         this.createdAt = output.getCreatedAt();
-        this.lastModified = output.getLastModified();
     }
 }

--- a/api/src/main/java/com/team/post/util/ImageUploader.java
+++ b/api/src/main/java/com/team/post/util/ImageUploader.java
@@ -28,8 +28,9 @@ public class ImageUploader {
         }
         String uploadFileName = multipartFile.getOriginalFilename();
         String storeFileName = createStoreFileName(uploadFileName);
-        multipartFile.transferTo(new File(getFullPath(storeFileName)));
-        return postImageService.save(new PostImage(uploadFileName, storeFileName));
+        String storePath = getFullPath(storeFileName);
+        multipartFile.transferTo(new File(storePath));
+        return postImageService.save(new PostImage(uploadFileName, storeFileName, storePath));
     }
 
     public List<PostImage> storeImages(List<MultipartFile> multipartFiles) {

--- a/api/src/main/java/com/team/user/UserController.java
+++ b/api/src/main/java/com/team/user/UserController.java
@@ -1,5 +1,9 @@
 package com.team.user;
 
+import com.team.post.PostService;
+import com.team.post.dto.input.FeedInput;
+import com.team.post.dto.output.FeedOutput;
+import com.team.post.dto.response.FeedResponse;
 import com.team.user.dto.input.FollowerInfoListInput;
 import com.team.user.dto.request.UserProfileModificationRequest;
 import com.team.user.dto.response.FollowListResponse;
@@ -10,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 @RestController
 @RequestMapping("/user")
@@ -18,6 +24,7 @@ public class UserController {
 
     private final UserService userService;
     private final FollowService followService;
+    private final PostService postService;
 
     @GetMapping("/{user-id}/followings")
     public ResponseEntity<FollowListResponse> getFollowList(@PathVariable(name="user-id") Long userId) {
@@ -40,5 +47,20 @@ public class UserController {
         userService.modifyUserProfile(userId, UserProfileModificationRequest.toServiceDto(reqDto));
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/{user-id}/feed")
+    public ResponseEntity<FeedResponse> getFeed(@PathVariable("user-id") Long userId,
+                                                @Valid @Positive @RequestParam("page-no") int page) {
+        FeedOutput feedOutput = getFeedOutput(userId, page);
+        return ResponseEntity.ok(new FeedResponse(feedOutput));
+    }
+
+    private FeedOutput getFeedOutput(Long userId, int page) {
+        FeedInput feedInput = FeedInput.builder()
+                .userId(userId)
+                .page(page)
+                .build();
+        return postService.getFeed(feedInput);
     }
 }

--- a/api/src/test/java/com/team/user/UserAcceptanceTest.java
+++ b/api/src/test/java/com/team/user/UserAcceptanceTest.java
@@ -3,10 +3,12 @@ package com.team.user;
 import com.team.dbutil.DatabaseCleanup;
 import com.team.dbutil.FollowData;
 import com.team.dbutil.UserData;
+import com.team.post.dto.response.FeedResponse;
 import com.team.user.dto.output.FollowListOutput;
 import com.team.user.dto.request.UserProfileModificationRequest;
 import com.team.user.dto.response.FollowerInfoListResponse;
 import com.team.user.dto.response.FollowerInfoResponse;
+import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -181,5 +184,52 @@ class UserAcceptanceTest {
         assertThat(response.getUsers().get(1).getName()).isEqualTo(user3.getName());
         assertThat(response.getUsers().get(1).getNickname()).isEqualTo(user3.getNickname());
         assertThat(response.getUsers().get(1).getFollowId()).isEqualTo(follow2.getId());
+    }
+
+    @Test
+    void 피드_조회() {
+        User user1 = userData.saveUser("testUser1", "testNickname1", "test1@test.com");
+        User user2 = userData.saveUser("testUser2", "testNickname2", "test2@test.com");
+        User user3 = userData.saveUser("testUser3", "testNickname3", "test3@test.com");
+        User user4 = userData.saveUser("testUser4", "testNickname4", "test4@test.com");
+
+        Follow follow1 = followData.saveFollow(user1, user2);
+        Follow follow2 = followData.saveFollow(user1, user3);
+
+        savePost(user2, "first");
+        savePost(user3, "second");
+        savePost(user4, "third");
+        savePost(user2, "fourth");
+
+        FeedResponse response =
+                given()
+                        .port(port)
+                        .accept("application/json")
+                        .param("page-no", 1)
+                        .when()
+                        .get("/user/{user-id}/feed", user1.getId())
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(FeedResponse.class);
+
+        assertThat(response.getFeedInfos().size()).isEqualTo(3);
+        assertThat(response.getFeedInfos().get(0).getContent()).isEqualTo("fourth");
+        assertThat(response.getFeedInfos().get(1).getContent()).isEqualTo("second");
+        assertThat(response.getFeedInfos().get(2).getContent()).isEqualTo("first");
+    }
+
+    private void savePost(User user, String content) {
+        String path = "src/test/resources/images";
+        String absolutePath = new File(path).getAbsolutePath();
+        given()
+                .port(port)
+                .accept(ContentType.JSON)
+                .multiPart("userId", user.getId())
+                .multiPart("content", content)
+                .multiPart("postImages", new File(absolutePath+"/apple.jpeg"))
+        .when()
+                .post("/post")
+        .then();
     }
 }

--- a/repository/build.gradle
+++ b/repository/build.gradle
@@ -8,4 +8,23 @@ jar {
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+    implementation 'com.querydsl:querydsl-core'
+    implementation 'com.querydsl:querydsl-jpa'
+    implementation 'com.querydsl:querydsl-apt'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+
+def generated='src/main/generated'
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
+
+clean.doLast {
+    file(generated).deleteDir()
 }

--- a/repository/src/main/java/com/team/comment/Comment.java
+++ b/repository/src/main/java/com/team/comment/Comment.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/repository/src/main/java/com/team/config/QueryDslConfig.java
+++ b/repository/src/main/java/com/team/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.team.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/repository/src/main/java/com/team/post/Post.java
+++ b/repository/src/main/java/com/team/post/Post.java
@@ -8,7 +8,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -31,23 +30,23 @@ public class Post {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private Set<PostImage> postImages = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private Set<PostLike> postLikes = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private Set<PostTaggedUser> postTaggedUsers = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private Set<PostTaggedKeyword> postTaggedKeywords = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private Set<Comment> comments = new LinkedHashSet<>();
 
     public Post(String content, User user) {
@@ -66,7 +65,7 @@ public class Post {
         this.postLikes.add(postLike);
     }
 
-    public void addTaggedUsers(List<PostTaggedUser> postTaggedUsers){
+    public void addTaggedUsers(List<PostTaggedUser> postTaggedUsers) {
         this.postTaggedUsers.addAll(postTaggedUsers);
     }
 
@@ -86,8 +85,6 @@ public class Post {
     }
 
     public void delete() {
-        this.user
-                .getPosts()
-                .remove(this);
+        this.user.getPosts().remove(this);
     }
 }

--- a/repository/src/main/java/com/team/post/Post.java
+++ b/repository/src/main/java/com/team/post/Post.java
@@ -1,6 +1,7 @@
 package com.team.post;
 
 import com.team.comment.Comment;
+import com.team.tag.PostTaggedKeyword;
 import com.team.tag.PostTaggedUser;
 import com.team.user.User;
 import lombok.AccessLevel;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -18,6 +20,7 @@ import java.util.Set;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,6 +45,9 @@ public class Post {
     private Set<PostTaggedUser> postTaggedUsers = new LinkedHashSet<>();
 
     @OneToMany(mappedBy = "post")
+    private Set<PostTaggedKeyword> postTaggedKeywords = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "post")
     private Set<Comment> comments = new LinkedHashSet<>();
 
     public Post(String content, User user) {
@@ -62,9 +68,10 @@ public class Post {
 
     public void addTaggedUsers(List<PostTaggedUser> postTaggedUsers){
         this.postTaggedUsers.addAll(postTaggedUsers);
-        postTaggedUsers.forEach(
-                it->it.setPost(this)
-        );
+    }
+
+    public void addTaggedKeywords(List<PostTaggedKeyword> postTaggedKeywords){
+        this.postTaggedKeywords.addAll(postTaggedKeywords);
     }
 
     public void addComment(Comment comment){
@@ -76,5 +83,11 @@ public class Post {
         postImages.forEach(
                 it->it.setPost(this)
         );
+    }
+
+    public void delete() {
+        this.user
+                .getPosts()
+                .remove(this);
     }
 }

--- a/repository/src/main/java/com/team/post/PostImage.java
+++ b/repository/src/main/java/com/team/post/PostImage.java
@@ -20,13 +20,16 @@ public class PostImage {
 
     private String storeFileName; // 서버 내부에서 관리하는 파일 이름
 
+    private String path; // 파일 저장 경로
+
     @JoinColumn(name = "post_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 
-    public PostImage(String uploadFileName, String storeFileName) {
+    public PostImage(String uploadFileName, String storeFileName, String path) {
         this.uploadFileName = uploadFileName;
         this.storeFileName = storeFileName;
+        this.path = path;
     }
 
     public void setPost(Post post){

--- a/repository/src/main/java/com/team/post/PostRepository.java
+++ b/repository/src/main/java/com/team/post/PostRepository.java
@@ -2,5 +2,5 @@ package com.team.post;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/repository/src/main/java/com/team/post/PostRepositoryCustom.java
+++ b/repository/src/main/java/com/team/post/PostRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.team.post;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+    List<Post> getFeed(Long userId, Pageable pageable);
+}

--- a/repository/src/main/java/com/team/post/PostRepositoryImpl.java
+++ b/repository/src/main/java/com/team/post/PostRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.team.post;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.team.post.QPost.post;
+import static com.team.user.QFollow.follow;
+import static com.team.user.QUser.user;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> getFeed(Long userId, Pageable pageable) {
+        return jpaQueryFactory.select(post)
+                .from(post, user, follow)
+                .where(
+                        userIdEq(userId),
+                        follow.followee.eq(post.user),
+                        follow.follower.eq(user)
+                )
+                .orderBy(post.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        if(userId == null || userId < 0) {
+            return null;
+        }
+        return user.id.eq(userId);
+    }
+}

--- a/repository/src/main/java/com/team/tag/PostTaggedKeyword.java
+++ b/repository/src/main/java/com/team/tag/PostTaggedKeyword.java
@@ -24,7 +24,7 @@ public class PostTaggedKeyword {
     @JoinColumn(name = "tag_keyword_id")
     private TagKeyword tagKeyword;
 
-    public PostTaggedKeyword(Post post, TagKeyword tagKeyword) {
+    public PostTaggedKeyword(TagKeyword tagKeyword, Post post) {
         this.post = post;
         this.tagKeyword = tagKeyword;
     }

--- a/repository/src/main/java/com/team/tag/PostTaggedKeywordRepository.java
+++ b/repository/src/main/java/com/team/tag/PostTaggedKeywordRepository.java
@@ -1,4 +1,6 @@
 package com.team.tag;
 
-public interface PostTaggedKeywordRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostTaggedKeywordRepository extends JpaRepository<PostTaggedKeyword, Long> {
 }

--- a/repository/src/main/java/com/team/tag/PostTaggedUser.java
+++ b/repository/src/main/java/com/team/tag/PostTaggedUser.java
@@ -28,8 +28,4 @@ public class PostTaggedUser {
         this.user = user;
         this.post = post;
     }
-
-    public void setPost(Post post){
-        this.post = post;
-    }
 }

--- a/repository/src/main/java/com/team/tag/TagKeyword.java
+++ b/repository/src/main/java/com/team/tag/TagKeyword.java
@@ -18,4 +18,8 @@ public class TagKeyword {
     private Long id;
 
     private String keyword;
+
+    public TagKeyword(String keyword) {
+        this.keyword = keyword;
+    }
 }

--- a/repository/src/main/java/com/team/tag/TagKeywordRepository.java
+++ b/repository/src/main/java/com/team/tag/TagKeywordRepository.java
@@ -2,5 +2,8 @@ package com.team.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TagKeywordRepository extends JpaRepository<TagKeyword, Long> {
+    Optional<TagKeyword> findByKeyword(String keyword);
 }

--- a/repository/src/test/java/com/team/config/TestConfig.java
+++ b/repository/src/test/java/com/team/config/TestConfig.java
@@ -1,0 +1,19 @@
+package com.team.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class TestConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/repository/src/test/java/com/team/post/PostRepositoryTest.java
+++ b/repository/src/test/java/com/team/post/PostRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.team.post;
+
+import com.team.config.TestConfig;
+import com.team.user.Follow;
+import com.team.user.FollowRepository;
+import com.team.user.User;
+import com.team.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestConfig.class)
+public class PostRepositoryTest {
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Test
+    void 피드_조회() throws InterruptedException {
+        User user1 = createUser("nickname1", "password1", "email1.com");
+        User user2 = createUser("nickname2", "password2", "email2.com");
+        User user3 = createUser("nickname3", "password3", "email3.com");
+        User user4 = createUser("nickname4", "password4", "email4.com");
+
+        Follow follow1 = createFollow(user1, user2);
+        Follow follow2 = createFollow(user1, user3);
+
+        Post post1 = createPost("first", user2);
+        Post post2 = createPost("second", user3);
+        Post post3 = createPost("third", user4);
+        Post post4 = createPost("fourth", user2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<Post> feed = postRepository.getFeed(user1.getId(), pageable);
+        assertThat(feed.size()).isEqualTo(3);
+    }
+
+    private Post createPost(String content ,User user) {
+        Post post = new Post(content, user);
+        return postRepository.save(post);
+    }
+
+    private Follow createFollow(User follower, User followee) {
+        Follow follow = new Follow(follower, followee);
+        return followRepository.save(follow);
+    }
+
+    private User createUser(String nickname, String password, String email) {
+        User user = User.builder()
+                .nickname(nickname)
+                .password(password)
+                .email(email)
+                .build();
+        return userRepository.save(user);
+    }
+
+}

--- a/repository/src/test/java/com/team/post/PostScrapRepositoryTest.java
+++ b/repository/src/test/java/com/team/post/PostScrapRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.team.post;
 
+import com.team.config.TestConfig;
 import com.team.user.User;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,6 +16,7 @@ import java.util.Comparator;
 import java.util.List;
 
 @DataJpaTest
+@Import(TestConfig.class)
 public class PostScrapRepositoryTest {
 
     @Autowired

--- a/repository/src/test/java/com/team/user/UserTest.java
+++ b/repository/src/test/java/com/team/user/UserTest.java
@@ -1,14 +1,17 @@
 package com.team.user;
 
+import com.team.config.TestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@Import(TestConfig.class)
 class UserTest {
     @Autowired
     private UserRepository userRepository;

--- a/service/src/main/java/com/team/post/PostService.java
+++ b/service/src/main/java/com/team/post/PostService.java
@@ -1,7 +1,9 @@
 package com.team.post;
 
 import com.team.exception.IdNotFoundException;
+import com.team.post.dto.input.FeedInput;
 import com.team.post.dto.input.SavePostInput;
+import com.team.post.dto.output.FeedOutput;
 import com.team.post.dto.output.SavePostOutput;
 import com.team.tag.PostTaggedKeyword;
 import com.team.tag.PostTaggedUser;
@@ -35,6 +37,11 @@ public class PostService {
         return new SavePostOutput(savePost);
     }
 
+    public FeedOutput getFeed(FeedInput input) {
+        List<Post> feed = postRepository.getFeed(input.getUserId(), input.of());
+        return new FeedOutput(feed);
+    }
+
     public void delete(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(IdNotFoundException::new);
@@ -49,16 +56,23 @@ public class PostService {
 
     private void tagUsers(SavePostInput input, Post post) {
         List<User> taggedUsers = getTaggedUsers(input.getTaggedUserIds());
-        List<PostTaggedUser> postTaggedUsers = taggedUserService.tagAll(taggedUsers, post);
-        post.addTaggedUsers(postTaggedUsers);
+        if (taggedUsers != null) {
+            List<PostTaggedUser> postTaggedUsers = taggedUserService.tagAll(taggedUsers, post);
+            post.addTaggedUsers(postTaggedUsers);
+        }
     }
 
     private void tagKeywords(SavePostInput input, Post post) {
         List<PostTaggedKeyword> postTaggedKeywords = postTaggedKeywordService.tagAll(input.getTaggedKeywords(), post);
-        post.addTaggedKeywords(postTaggedKeywords);
+        if (postTaggedKeywords != null) {
+            post.addTaggedKeywords(postTaggedKeywords);
+        }
     }
 
     private List<User> getTaggedUsers(List<Long> userIds) {
+        if(userIds == null) {
+            return null;
+        }
         return userIds.stream()
                 .map(userService::findUserById)
                 .collect(Collectors.toList());

--- a/service/src/main/java/com/team/post/PostService.java
+++ b/service/src/main/java/com/team/post/PostService.java
@@ -1,7 +1,9 @@
 package com.team.post;
 
+import com.team.exception.IdNotFoundException;
 import com.team.post.dto.input.SavePostInput;
 import com.team.post.dto.output.SavePostOutput;
+import com.team.tag.PostTaggedKeyword;
 import com.team.tag.PostTaggedUser;
 import com.team.user.User;
 import com.team.user.UserService;
@@ -20,6 +22,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostImageService postImageService;
     private final PostTaggedUserService taggedUserService;
+    private final PostTaggedKeywordService postTaggedKeywordService;
 
     public SavePostOutput save(SavePostInput input) {
         User user = userService.findUserById(input.getUserId());
@@ -28,7 +31,15 @@ public class PostService {
 
         addImages(input, savePost);
         tagUsers(input, savePost);
+        tagKeywords(input, savePost);
         return new SavePostOutput(savePost);
+    }
+
+    public void delete(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(IdNotFoundException::new);
+        post.delete();
+        postRepository.delete(post);
     }
 
     private void addImages(SavePostInput input, Post post) {
@@ -40,6 +51,11 @@ public class PostService {
         List<User> taggedUsers = getTaggedUsers(input.getTaggedUserIds());
         List<PostTaggedUser> postTaggedUsers = taggedUserService.tagAll(taggedUsers, post);
         post.addTaggedUsers(postTaggedUsers);
+    }
+
+    private void tagKeywords(SavePostInput input, Post post) {
+        List<PostTaggedKeyword> postTaggedKeywords = postTaggedKeywordService.tagAll(input.getTaggedKeywords(), post);
+        post.addTaggedKeywords(postTaggedKeywords);
     }
 
     private List<User> getTaggedUsers(List<Long> userIds) {

--- a/service/src/main/java/com/team/post/PostTaggedKeywordService.java
+++ b/service/src/main/java/com/team/post/PostTaggedKeywordService.java
@@ -1,0 +1,38 @@
+package com.team.post;
+
+import com.team.tag.PostTaggedKeyword;
+import com.team.tag.PostTaggedKeywordRepository;
+import com.team.tag.TagKeyword;
+import com.team.tag.TagKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostTaggedKeywordService {
+    private final TagKeywordRepository tagKeywordRepository;
+    private final PostTaggedKeywordRepository postTaggedKeywordRepository;
+
+    public List<PostTaggedKeyword> tagAll(List<String> keywords, Post post) {
+        List<PostTaggedKeyword> postTaggedKeywords = new ArrayList<>();
+        for (String keyword : keywords) {
+            TagKeyword tagKeyword = getTagKeyword(keyword); // 키워드가 존재한다면 오브젝트 반환, 존재하지 않으면 null 반환
+            if (tagKeyword == null) {
+                tagKeyword = tagKeywordRepository.save(new TagKeyword(keyword)); // 키워드로 등록
+            }
+            PostTaggedKeyword postTaggedKeyword = postTaggedKeywordRepository.save(new PostTaggedKeyword(tagKeyword, post));
+            postTaggedKeywords.add(postTaggedKeyword);
+        }
+        return postTaggedKeywords;
+    }
+
+    private TagKeyword getTagKeyword(String keyword) {
+        return tagKeywordRepository.findByKeyword(keyword)
+                .orElse(null);
+    }
+}

--- a/service/src/main/java/com/team/post/PostTaggedKeywordService.java
+++ b/service/src/main/java/com/team/post/PostTaggedKeywordService.java
@@ -19,6 +19,10 @@ public class PostTaggedKeywordService {
     private final PostTaggedKeywordRepository postTaggedKeywordRepository;
 
     public List<PostTaggedKeyword> tagAll(List<String> keywords, Post post) {
+        if (keywords == null) {
+            return null;
+        }
+
         List<PostTaggedKeyword> postTaggedKeywords = new ArrayList<>();
         for (String keyword : keywords) {
             TagKeyword tagKeyword = getTagKeyword(keyword); // 키워드가 존재한다면 오브젝트 반환, 존재하지 않으면 null 반환

--- a/service/src/main/java/com/team/post/PostTaggedUserService.java
+++ b/service/src/main/java/com/team/post/PostTaggedUserService.java
@@ -17,6 +17,10 @@ public class PostTaggedUserService {
     private final PostTaggedUserRepository taggedUserRepository;
 
     public List<PostTaggedUser> tagAll(List<User> users, Post post) {
+        if (users == null) {
+            return null;
+        }
+
         return users.stream()
                 .map(it -> taggedUserRepository.save(new PostTaggedUser(it, post)))
                 .collect(Collectors.toList());

--- a/service/src/main/java/com/team/post/dto/input/FeedInput.java
+++ b/service/src/main/java/com/team/post/dto/input/FeedInput.java
@@ -1,0 +1,24 @@
+package com.team.post.dto.input;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedInput {
+    private Long userId;
+    private int page;
+
+    @Builder
+    public FeedInput(Long userId, int page) {
+        this.userId = userId;
+        this.page = page;
+    }
+
+    public PageRequest of() {
+        return PageRequest.of(page - 1, 10);
+    }
+}

--- a/service/src/main/java/com/team/post/dto/input/SavePostInput.java
+++ b/service/src/main/java/com/team/post/dto/input/SavePostInput.java
@@ -14,12 +14,14 @@ public class SavePostInput {
     private String content;
     private List<Long> postImageIds;
     private List<Long> taggedUserIds;
+    private List<String> taggedKeywords;
 
     @Builder
-    public SavePostInput(Long userId, String content, List<Long> postImageIds, List<Long> taggedUserIds) {
+    public SavePostInput(Long userId, String content, List<Long> postImageIds, List<Long> taggedUserIds, List<String> taggedKeywords) {
         this.userId = userId;
         this.content = content;
         this.postImageIds = postImageIds;
         this.taggedUserIds = taggedUserIds;
+        this.taggedKeywords = taggedKeywords;
     }
 }

--- a/service/src/main/java/com/team/post/dto/output/FeedOutput.java
+++ b/service/src/main/java/com/team/post/dto/output/FeedOutput.java
@@ -1,0 +1,50 @@
+package com.team.post.dto.output;
+
+import com.team.post.Post;
+import com.team.post.PostImage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedOutput {
+    private List<FeedInfo> feedInfos;
+
+    public FeedOutput(List<Post> posts) {
+        this.feedInfos = posts.stream()
+                .map(FeedInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FeedInfo {
+        private Long userId;
+        private Long postId;
+        private String nickname;
+        private String profileImage;
+        private String content;
+        private String createdAt;
+        private List<String> imagePaths;
+        private List<String> uploadImageNames;
+        private int likeCount;
+        private int commentCount;
+
+        public FeedInfo(Post post) {
+            this.userId = post.getUser().getId();
+            this.postId = post.getId();
+            this.nickname = post.getUser().getNickname();
+            this.profileImage = post.getUser().getProfileImage();
+            this.content = post.getContent();
+            this.createdAt = post.getCreatedAt().toString();
+            this.imagePaths = post.getPostImages().stream().map(PostImage::getPath).collect(Collectors.toList());
+            this.uploadImageNames = post.getPostImages().stream().map(PostImage::getUploadFileName).collect(Collectors.toList());
+            this.likeCount = post.getPostLikes().size();
+            this.commentCount = post.getComments().size();
+        }
+    }
+}

--- a/service/src/main/java/com/team/post/dto/output/SavePostOutput.java
+++ b/service/src/main/java/com/team/post/dto/output/SavePostOutput.java
@@ -2,6 +2,8 @@ package com.team.post.dto.output;
 
 import com.team.post.Post;
 import com.team.post.PostImage;
+import com.team.tag.PostTaggedKeyword;
+import com.team.tag.TagKeyword;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,18 +21,18 @@ public class SavePostOutput {
     private String content;
     private List<String> postImages;
     private List<Long> taggedUserIds;
+    private List<String> taggedKeywords;
     private LocalDateTime createdAt;
-    private LocalDateTime lastModified;
 
     @Builder
-    public SavePostOutput(Long userId, Long postId, String content, List<String> postImages, List<Long> taggedUserIds, LocalDateTime createdAt, LocalDateTime lastModified) {
+    public SavePostOutput(Long userId, Long postId, String content, List<String> postImages, List<Long> taggedUserIds, List<String> taggedKeywords, LocalDateTime createdAt) {
         this.userId = userId;
         this.postId = postId;
         this.content = content;
         this.postImages = postImages;
         this.taggedUserIds = taggedUserIds;
+        this.taggedKeywords = taggedKeywords;
         this.createdAt = createdAt;
-        this.lastModified = lastModified;
     }
 
     public SavePostOutput(Post post) {
@@ -39,7 +41,7 @@ public class SavePostOutput {
         this.content = post.getContent();
         this.postImages = post.getPostImages().stream().map(PostImage::getUploadFileName).collect(Collectors.toList());
         this.taggedUserIds = post.getPostTaggedUsers().stream().map(it -> it.getUser().getId()).collect(Collectors.toList());
+        this.taggedKeywords = post.getPostTaggedKeywords().stream().map(PostTaggedKeyword::getTagKeyword).map(TagKeyword::getKeyword).collect(Collectors.toList());
         this.createdAt = post.getCreatedAt();
-        this.lastModified = post.getLastModified();
     }
 }

--- a/service/src/test/java/com/team/post/PostImageServiceTest.java
+++ b/service/src/test/java/com/team/post/PostImageServiceTest.java
@@ -37,8 +37,8 @@ class PostImageServiceTest {
                 .password("testPassword")
                 .build();
 
-        postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg");
-        postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg");
+        postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg", "src/images/11111111-1111-1111-1111-111111111111.jpg");
+        postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg", "src/images/22222222-2222-2222-2222-222222222222.jpg");
     }
 
     @Test

--- a/service/src/test/java/com/team/post/PostScrapServiceTest.java
+++ b/service/src/test/java/com/team/post/PostScrapServiceTest.java
@@ -42,11 +42,11 @@ public class PostScrapServiceTest {
     @BeforeEach
     void setUp() {
         user = User.builder()
+                .id(1L)
                 .name("백승화")
                 .email("a@naver.com")
                 .nickname("peach")
                 .build();
-        user.setIdForTest(1L);
         post = new Post("hello" ,user);
         post2 = new Post("hello2" ,user);
         postScrap = new PostScrap(user, post);

--- a/service/src/test/java/com/team/post/PostServiceTest.java
+++ b/service/src/test/java/com/team/post/PostServiceTest.java
@@ -2,7 +2,9 @@ package com.team.post;
 
 import com.team.post.dto.input.SavePostInput;
 import com.team.post.dto.output.SavePostOutput;
+import com.team.tag.PostTaggedKeyword;
 import com.team.tag.PostTaggedUser;
+import com.team.tag.TagKeyword;
 import com.team.user.User;
 import com.team.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +37,9 @@ class PostServiceTest {
     @Mock
     private PostTaggedUserService postTaggedUserService;
 
+    @Mock
+    private PostTaggedKeywordService postTaggedKeywordService;
+
     @InjectMocks
     private PostService postService;
 
@@ -43,63 +49,62 @@ class PostServiceTest {
 
     private Post post;
 
-    private PostImage postImage1;
-    private PostImage postImage2;
-    private List<PostImage> postImages;
-
-    private PostTaggedUser userTag1;
-    private PostTaggedUser userTag2;
-    private List<PostTaggedUser> userTags;
-
     @BeforeEach
     void setUp() {
         user1 = User.builder()
+                .id(1L)
                 .name("testUser1")
                 .nickname("testNickname1")
                 .email("test1@test.com")
                 .password("testPassword1")
                 .build();
-        user1.setIdForTest(1L);
 
         user2 = User.builder()
+                .id(2L)
                 .name("testUser2")
                 .nickname("testNickname2")
                 .email("test2@test.com")
                 .password("testPassword2")
                 .build();
-        user2.setIdForTest(2L);
 
         user3 = User.builder()
+                .id(3L)
                 .name("testUser3")
                 .nickname("testNickname3")
                 .email("test3@test.com")
                 .password("testPassword3")
                 .build();
-        user3.setIdForTest(3L);
 
         post = new Post("test-content", user1);
-
-        postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg");
-        postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg");
-        postImages = Arrays.asList(postImage1, postImage2);
-
-        userTag1 = new PostTaggedUser(user2, post);
-        userTag2 = new PostTaggedUser(user3, post);
-        userTags = Arrays.asList(userTag1, userTag2);
+        post.setIdForTest(1L);
     }
 
     @Test
     void 게시글_저장() {
+        PostImage postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg");
+        PostImage postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg");;
+        List<PostImage> postImages = Arrays.asList(postImage1, postImage2);
+
+        PostTaggedUser userTag1 = new PostTaggedUser(user2, post);
+        PostTaggedUser userTag2 = new PostTaggedUser(user3, post);
+        List<PostTaggedUser> userTags = Arrays.asList(userTag1, userTag2);
+
+        PostTaggedKeyword keywordTag1 = new PostTaggedKeyword(new TagKeyword("inMoongram"), post);
+        PostTaggedKeyword keywordTag2 = new PostTaggedKeyword(new TagKeyword("spring"), post);
+        List<PostTaggedKeyword> keywordTags = Arrays.asList(keywordTag1, keywordTag2);
+
         given(userService.findUserById(any())).willReturn(user1).willReturn(user2).willReturn(user3);
         given(postImageService.findImagesByIds(any())).willReturn(postImages);
         given(postRepository.save(any())).willReturn(post);
         given(postTaggedUserService.tagAll(any(), any())).willReturn(userTags);
+        given(postTaggedKeywordService.tagAll(any(), any())).willReturn(keywordTags);
 
         SavePostInput input = SavePostInput.builder()
                 .userId(user1.getId())
                 .content("test-content")
                 .postImageIds(postImages.stream().map(PostImage::getId).collect(Collectors.toList()))
                 .taggedUserIds(Arrays.asList(user2.getId(), user3.getId()))
+                .taggedKeywords(Arrays.asList("inMoongram", "spring"))
                 .build();
 
         SavePostOutput output = postService.save(input);
@@ -111,5 +116,16 @@ class PostServiceTest {
         assertThat(output.getTaggedUserIds().size()).isEqualTo(2);
         assertThat(output.getTaggedUserIds().get(0)).isEqualTo(user2.getId());
         assertThat(output.getTaggedUserIds().get(1)).isEqualTo(user3.getId());
+        assertThat(output.getTaggedKeywords().size()).isEqualTo(2);
+        assertThat(output.getTaggedKeywords().get(0)).isEqualTo(keywordTag1.getTagKeyword().getKeyword());
+        assertThat(output.getTaggedKeywords().get(1)).isEqualTo(keywordTag2.getTagKeyword().getKeyword());
+    }
+
+    @Test
+    void 게시글_삭제() {
+        given(postRepository.findById(any())).willReturn(Optional.of(post));
+        postService.delete(post.getId());
+
+        assertThat(user1.getPosts().size()).isEqualTo(0);
     }
 }

--- a/service/src/test/java/com/team/post/PostServiceTest.java
+++ b/service/src/test/java/com/team/post/PostServiceTest.java
@@ -81,8 +81,8 @@ class PostServiceTest {
 
     @Test
     void 게시글_저장() {
-        PostImage postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg");
-        PostImage postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg");;
+        PostImage postImage1 = new PostImage("image1.jpg", "11111111-1111-1111-1111-111111111111.jpg", "src/images/11111111-1111-1111-1111-111111111111.jpg");
+        PostImage postImage2 = new PostImage("image2.jpg", "22222222-2222-2222-2222-222222222222.jpg", "src/images/22222222-2222-2222-2222-222222222222.jpg");;
         List<PostImage> postImages = Arrays.asList(postImage1, postImage2);
 
         PostTaggedUser userTag1 = new PostTaggedUser(user2, post);

--- a/service/src/test/java/com/team/post/PostTaggedKeywordServiceTest.java
+++ b/service/src/test/java/com/team/post/PostTaggedKeywordServiceTest.java
@@ -1,0 +1,70 @@
+package com.team.post;
+
+import com.team.tag.*;
+import com.team.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PostTaggedKeywordServiceTest {
+    @Mock
+    private PostTaggedKeywordRepository postTaggedKeywordRepository;
+
+    @Mock
+    private TagKeywordRepository tagKeywordRepository;
+
+    @InjectMocks
+    private PostTaggedKeywordService postTaggedKeywordService;
+
+    private User user;
+
+    private Post post;
+
+    private TagKeyword tag1;
+    private TagKeyword tag2;
+
+    private PostTaggedKeyword taggedKeyword1;
+    private PostTaggedKeyword taggedKeyword2;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .name("testUser1")
+                .nickname("testNickname1")
+                .email("test1@test.com")
+                .password("testPassword1")
+                .build();
+
+        post = new Post("test-content", user);
+
+        tag1 = new TagKeyword("inMoongram");
+        tag2 = new TagKeyword("spring");
+
+        taggedKeyword1 = new PostTaggedKeyword(tag1, post);
+        taggedKeyword2 = new PostTaggedKeyword(tag2, post);
+    }
+
+    @Test
+    void tagAll() {
+        given(tagKeywordRepository.findByKeyword(any())).willReturn(Optional.of(tag1)).willReturn(Optional.of(tag2));
+        given(postTaggedKeywordRepository.save(any())).willReturn(taggedKeyword1).willReturn(taggedKeyword2);
+        List<PostTaggedKeyword> output = postTaggedKeywordService.tagAll(Arrays.asList("inMoongram", "spring"), post);
+
+        assertThat(output.size()).isEqualTo(2);
+        assertThat(output.get(0).getTagKeyword().getKeyword()).isEqualTo("inMoongram");
+        assertThat(output.get(1).getTagKeyword().getKeyword()).isEqualTo("spring");
+    }
+}

--- a/service/src/test/java/com/team/post/PostTaggedUserServiceTest.java
+++ b/service/src/test/java/com/team/post/PostTaggedUserServiceTest.java
@@ -38,26 +38,26 @@ class PostTaggedUserServiceTest {
     @BeforeEach
     void setUp() {
         user1 = User.builder()
+                .id(1L)
                 .name("testUser1")
                 .nickname("testNickname1")
                 .email("test1@test.com")
                 .password("testPassword1")
                 .build();
-        user1.setIdForTest(1L);
         user2 = User.builder()
+                .id(2L)
                 .name("testUser2")
                 .nickname("testNickname2")
                 .email("test2@test.com")
                 .password("testPassword2")
                 .build();
-        user2.setIdForTest(2L);
         user3 = User.builder()
+                .id(3L)
                 .name("testUser3")
                 .nickname("testNickname3")
                 .email("test3@test.com")
                 .password("testPassword3")
                 .build();
-        user3.setIdForTest(3L);
 
         post = new Post("test-content", user1);
 

--- a/service/src/test/java/com/team/user/FollowServiceTest.java
+++ b/service/src/test/java/com/team/user/FollowServiceTest.java
@@ -37,20 +37,21 @@ class FollowServiceTest {
     @BeforeEach
     void setUp() {
         user1 = User.builder()
+                .id(1L)
                 .name("testUser1")
                 .nickname("testNickname1")
                 .email("test1@test.com")
                 .password("testPassword1")
                 .build();
-        user1.setIdForTest(1L);
         user2 = User.builder()
+                .id(2L)
                 .name("testUser2")
                 .nickname("testNickname2")
                 .email("test2@test.com")
                 .password("testPassword2")
                 .build();
-        user2.setIdForTest(2L);
         user3 = User.builder()
+                .id(3L)
                 .name("testUser3")
                 .nickname("testNickname3")
                 .email("test3@test.com")


### PR DESCRIPTION
-- 참고사항 --
- `@createdAt`을 사용하기 위해 JpaAuditing 설정을 추가했습니다.
- Post 삭제 시, 다른 엔티티와의 관계 삭제를 위해 cascade를 추가했습니다.
- PostController(savePost): 이미지 저장과 게시글 저장의 순서는 바꾸지 못했습니다. 잘 안되네요 ㅠ